### PR TITLE
Add functions and cases for filter methods for aoc

### DIFF
--- a/R/filter-aov.R
+++ b/R/filter-aov.R
@@ -7,40 +7,119 @@ filter_aov <- function(
     subclass = c("any"),
     outcome_type = c("numeric", "factor"),
     predictor_type = c("numeric", "factor"),
-    case_weights = case_weights,
+    case_weights = FALSE, # To do
     range = range,
     inclusive = c(TRUE, TRUE),
     fallback_value = Inf,
-    score_type = score_type,
+    score_type = c("fstat"), # Add "pval"
     trans = NULL, # To do
     sorts = NULL, # To do
-    direction = direction,
+    direction = "maximize",
     deterministic = TRUE,
     tuning = FALSE,
-    ties = ties,
+    ties = NULL,
     calculating_fn = get_f_stat,
     label = c(filter_aov = "Filter method based on ANOVA F-statistics")
   )
 }
 
-# To do: Helper function to check if a vector is a factor with 2+ levels
-# flip x, y if needed, e.g., lm(y~x) and lm(x~y). Pass to get_f_stat.
+flip_if_needed_aov <- function(x, y) {
+  if (is.factor(y) && is.numeric(x)) {
+    list(predictor = y, outcome = x)
+  } else {
+    list(predictor = x, outcome = y)
+  }
+}
 
 get_f_stat <- function(predictor, outcome) {
-  if (length(levels(outcome)) == 2) {
+  flipped <- flip_if_needed_aov(x = predictor, y = outcome)
+  outcome <- flipped$outcome
+  predictor <- flipped$predictor
+
+  if (length(levels(predictor)) == 2) {
     fit <- lm(outcome ~ predictor)
-    res <- summary(fit)$fstatistic[1]
+    res <- anova(fit)$`F value`[1] # summary(fit)$fstatistic[1] |> as.numeric()
   } else {
     fit <- lm(outcome ~ predictor)
-    res <- summary(fit)$fstatistic[1]
+    res <- anova(fit)$`F value`[1] # summary(fit)$fstatistic[1] |> as.numeric()
   }
   res
 }
 
-# To do:
-# Need a for loop or map to handle all predictor-outcome pairs
+get_score_aov <- function(filter_obj, data, outcome) {
+  predictors <- setdiff(names(data), outcome)
+
+  score <- purrr::map_dbl(
+    purrr::set_names(predictors),
+    ~ {
+      predictor_col <- data[[.x]]
+      outcome_col <- data[[outcome]]
+
+      if (is.factor(outcome_col) && !is.numeric(predictor_col)) {
+        return(NA_real_)
+      }
+
+      if (is.numeric(outcome_col) && !is.factor(predictor_col)) {
+        return(NA_real_)
+      }
+
+      get_f_stat(predictor_col, outcome_col)
+    }
+  )
+  names <- names(score)
+  res <- dplyr::tibble(
+    name = filter_obj$score_type,
+    score = unname(score),
+    outcome = outcome,
+    predictor = names
+  )
+}
 
 # To do:
 # get_p_val <- function() {
 #   ...
 # }
+
+get_p_val <- function(predictor, outcome) {
+  flipped <- flip_if_needed_aov(x = predictor, y = outcome)
+  outcome <- flipped$outcome
+  predictor <- flipped$predictor
+
+  if (length(levels(predictor)) == 2) {
+    fit <- lm(outcome ~ predictor)
+    res <- anova(fit)$`Pr(>F)`[1]
+  } else {
+    fit <- lm(outcome ~ predictor)
+    res <- anova(fit)$`Pr(>F)`[1]
+  }
+  res
+}
+
+get_score_aov_p_val <- function(filter_obj, data, outcome) {
+  predictors <- setdiff(names(data), outcome)
+
+  score <- purrr::map_dbl(
+    purrr::set_names(predictors),
+    ~ {
+      predictor_col <- data[[.x]]
+      outcome_col <- data[[outcome]]
+
+      if (is.factor(outcome_col) && !is.numeric(predictor_col)) {
+        return(NA_real_)
+      }
+
+      if (is.numeric(outcome_col) && !is.factor(predictor_col)) {
+        return(NA_real_)
+      }
+
+      get_p_val(predictor_col, outcome_col)
+    }
+  )
+  names <- names(score)
+  res <- dplyr::tibble(
+    name = filter_obj$score_type,
+    score = unname(score),
+    outcome = outcome,
+    predictor = names
+  )
+}

--- a/R/filter-roc_auc.R
+++ b/R/filter-roc_auc.R
@@ -3,7 +3,7 @@ filter_roc_auc <- function(range = c(0, 1), trans = NULL) {
     subclass = c("any"),
     outcome_type = c("numeric", "factor"),
     predictor_type = c("numeric", "factor"),
-    case_weights = FALSE,
+    case_weights = FALSE, # To do
     range = range,
     inclusive = c(TRUE, TRUE),
     fallback_value = 1,

--- a/misc/informal_test_filter_aov.R
+++ b/misc/informal_test_filter_aov.R
@@ -1,0 +1,67 @@
+data(iris)
+iris |> str()
+
+# Test lm
+outcome <- iris$Sepal.Length
+predictor <- iris$Species
+fit <- lm(outcome ~ predictor)
+#res <- summary(fit)$fstatistic[1] |> as.numeric()
+res <- anova(fit)$`F value`[1]
+res <- anova(fit)$`Pr(>F)`[1]
+
+# Test flip_if_needed_aov
+outcome <- iris$Sepal.Length
+predictor <- iris$Species
+flipped <- flip_if_needed_aov(x = predictor, y = outcome)
+flipped$outcome |> class()
+flipped$predictor |> class()
+
+outcome <- iris$Species
+predictor <- iris$Sepal.Length
+flipped <- flip_if_needed_aov(x = predictor, y = outcome)
+flipped$outcome |> class()
+flipped$predictor |> class()
+
+# Test get_f_stat
+outcome <- iris$Sepal.Length
+predictor <- iris$Species
+get_f_stat(predictor, outcome)
+
+outcome <- iris$Species
+predictor <- iris$Sepal.Length
+get_f_stat(predictor, outcome)
+
+# Test get_p_val Note: Can probably write this inside get_f_stat
+outcome <- iris$Sepal.Length
+predictor <- iris$Species
+get_p_val(predictor, outcome)
+
+outcome <- iris$Species
+predictor <- iris$Sepal.Length
+get_p_val(predictor, outcome)
+
+# Test get_score
+data(iris)
+data <- iris
+outcome <- "Sepal.Length"
+filter_obj <- filter_aov()
+tbl_iris <- get_score_aov(filter_obj, data, outcome)
+tbl_iris
+
+outcome <- "Species"
+filter_obj <- filter_aov()
+tbl_iris <- get_score_aov(filter_obj, data, outcome)
+tbl_iris
+
+# Test get_score_aov_p_val Note: Can probably write this inside get_f_stat
+data(iris)
+data <- iris
+outcome <- "Sepal.Length"
+filter_obj <- filter_aov()
+tbl_iris <- get_score_aov_p_val(filter_obj, data, outcome)
+tbl_iris
+
+outcome <- "Species"
+filter_obj <- filter_aov()
+tbl_iris <- get_score_aov_p_val(filter_obj, data, outcome)
+tbl_iris


### PR DESCRIPTION
This PR includes the following changes:

- Add `get_f_stat`
- Add `get_p_val`
- Add `get_score_aov`
- Add `get_score_aov_p_val`
- Rewrite the above 4 functions into 2 functions. Use `score_type =` to control the naming (e.g., currently, names = `fstat`, but should be names = `pval`.

iris
```
> data(iris)
+ data <- iris
+ outcome <- "Sepal.Length"
+ filter_obj <- filter_aov()
+ tbl_iris <- get_score_aov_p_val(filter_obj, data, outcome)
+ tbl_iris
# A tibble: 4 × 4
  name      score outcome      predictor   
  <chr>     <dbl> <chr>        <chr>       
1 fstat NA        Sepal.Length Sepal.Width 
2 fstat NA        Sepal.Length Petal.Length
3 fstat NA        Sepal.Length Petal.Width 
4 fstat  1.67e-31 Sepal.Length Species     
> outcome <- "Species"
+ filter_obj <- filter_aov()
+ tbl_iris <- get_score_aov_p_val(filter_obj, data, outcome)
+ tbl_iris
# A tibble: 4 × 4
  name     score outcome predictor   
  <chr>    <dbl> <chr>   <chr>       
1 fstat 1.67e-31 Species Sepal.Length
2 fstat 4.49e-17 Species Sepal.Width 
3 fstat 2.86e-91 Species Petal.Length
4 fstat 4.17e-85 Species Petal.Width 
```

To do: 

- [ ] Rewrite. Use `score_type =`. 