### PR TITLE
Add more tests starting from forest imp

### DIFF
--- a/tests/testthat/helper-hpc_data.R
+++ b/tests/testthat/helper-hpc_data.R
@@ -1,0 +1,4 @@
+helper_hpc_data <- function() {
+  data <- modeldata::hpc_data
+  data
+}

--- a/tests/testthat/test-score-forest_imp.R
+++ b/tests/testthat/test-score-forest_imp.R
@@ -1,5 +1,3 @@
-# TODO Revise after we have helpers to change fields such as trees, mtry, min_n
-
 test_that("object creation", {
   expect_s3_class(
     score_imp_rf,
@@ -231,7 +229,12 @@ test_that("computations - regression task via aorsf", {
   expect_equal(ames_imp_rf_oblique_res@direction, "maximize")
 })
 
-# TODO Wrong variable type
-# TODO Required packages
+# TODO computations - wrong variable types
+
+test_that("computations - required packages", {
+  expect_equal(required_pkgs(score_imp_rf), "filtro")
+  expect_equal(required_pkgs(score_imp_rf_conditional), "filtro")
+  expect_equal(required_pkgs(score_imp_rf_oblique), "filtro")
+})
 
 # TODO Test more after we add validators

--- a/tests/testthat/test-score-forest_imp.R
+++ b/tests/testthat/test-score-forest_imp.R
@@ -1,3 +1,5 @@
+# TODO Revise after we have helpers to change fields such as trees, mtry, min_n
+
 test_that("object creation", {
   expect_s3_class(
     score_imp_rf,
@@ -15,11 +17,11 @@ test_that("object creation", {
   )
 })
 
-test_that("computations - class outcome via ranger", {
+test_that("computations - classification task via ranger", {
   skip_if_not_installed("modeldata")
   cells_subset <- helper_cells()
 
-  score_imp_rf@seed = 42
+  score_imp_rf@seed <- 42
   cells_imp_rf_res <- score_imp_rf |>
     fit(class ~ ., data = cells_subset)
 
@@ -49,7 +51,7 @@ test_that("computations - class outcome via ranger", {
   expect_equal(cells_imp_rf_res@direction, "maximize")
 })
 
-test_that("computations - class outcome via partykit", {
+test_that("computations - classification task via partykit", {
   skip_if_not_installed("modeldata")
   cells_subset <- helper_cells()
 
@@ -82,7 +84,7 @@ test_that("computations - class outcome via partykit", {
   expect_equal(cells_imp_rf_conditional_res@direction, "maximize")
 })
 
-test_that("computations - class outcome via aorsf", {
+test_that("computations - classification task via aorsf", {
   skip_if_not_installed("modeldata")
   cells_subset <- helper_cells()
 
@@ -115,280 +117,121 @@ test_that("computations - class outcome via aorsf", {
   expect_equal(cells_imp_rf_oblique_res@direction, "maximize")
 })
 
-# regression task
-ames_subset <- modeldata::ames |>
-  dplyr::select(
-    Sale_Price,
-    MS_SubClass,
-    MS_Zoning,
-    Lot_Frontage,
-    Lot_Area,
-    Street
-  )
-ames_subset <- ames_subset |>
-  dplyr::mutate(Sale_Price = log10(Sale_Price))
-
-regression_task <- score_imp_rf
-regression_task@mode <- "regression"
-
-set.seed(42)
-ames_imp_rf_regression_task_res <-
-  regression_task |>
-  fit(Sale_Price ~ ., data = ames_subset)
-ames_imp_rf_regression_task_res@results
-
-# other configuration
-rf_config <- score_imp_rf
-# tuning parameters
-rf_config@trees <- 100
-rf_config@mtry <- 2
-rf_config@min_n <- 1
-# relevant only for ranger
-rf_config@mode <- "regression"
-rf_config@seed <- 42
-
-set.seed(42)
-ames_imp_rf_config_res <-
-  rf_config |>
-  fit(Sale_Price ~ ., data = ames_subset)
-ames_imp_rf_config_res@results
-
-skip()
-
-test_that("get_score_forest_importance() is working for ranger for classification", {
+test_that("computations - regression task via ranger", {
   skip_if_not_installed("modeldata")
-
-  cells_subset <- helper_cells()
-  score_obj <- score_forest_imp(seed = 42)
-  score_res <- get_scores_forest_importance(
-    score_obj,
-    data = cells_subset,
-    outcome = "class"
-  )
-
-  outcome <- "class"
-  y <- cells_subset[[outcome]]
-  X <- cells_subset[setdiff(names(cells_subset), outcome)]
-  fit <- ranger::ranger(
-    y = y,
-    x = X,
-    num.trees = 10,
-    mtry = 2,
-    importance = "permutation",
-    min.node.size = 1,
-    classification = TRUE,
-    seed = 42
-  )
-  exp.res <- unname(fit$variable.importance)
-
-  expect_true(tibble::is_tibble(score_res))
-
-  expect_identical(nrow(score_res), ncol(cells_subset) - 1L)
-
-  expect_named(score_res, c("name", "score", "outcome", "predictor"))
-
-  expect_identical(score_res$score, exp.res)
-
-  expect_equal(unique(score_res$name), "imp_rf")
-
-  expect_equal(unique(score_res$outcome), "class")
-})
-
-test_that("get_score_forest_importance() is working for partykit classification", {
-  skip_if_not_installed("modeldata")
-
-  cells_subset <- helper_cells()
-  score_obj <- score_forest_imp(engine = "partykit")
-
-  set.seed(42)
-  score_res <- get_scores_forest_importance(
-    score_obj,
-    data = cells_subset,
-    outcome = "class"
-  )
-
-  set.seed(42)
-  fit <- partykit::cforest(
-    formula = class ~ .,
-    data = cells_subset,
-    control = partykit::ctree_control(minsplit = 1), # TODO Eventually have user pass in ctree_control()
-    ntree = 10,
-    mtry = 2,
-  )
-  imp <- partykit::varimp(fit, conditional = TRUE)
-  outcome <- "class"
-  predictors <- setdiff(names(cells_subset), outcome)
-  exp.imp <- imp[predictors] |> unname()
-  exp.imp[is.na(exp.imp)] <- 0
-
-  expect_true(tibble::is_tibble(score_res))
-
-  expect_identical(nrow(score_res), ncol(cells_subset) - 1L)
-
-  expect_named(score_res, c("name", "score", "outcome", "predictor"))
-
-  expect_identical(score_res$score, exp.imp)
-
-  expect_equal(unique(score_res$name), "imp_rf_conditional")
-
-  expect_equal(unique(score_res$outcome), "class")
-})
-
-test_that("get_score_forest_importance() is working for aorsf classification", {
-  skip_if_not_installed("modeldata")
-
-  cells_subset <- helper_cells()
-  score_obj <- score_forest_imp(engine = "aorsf")
-
-  set.seed(42)
-  score_res <- get_scores_forest_importance(
-    score_obj,
-    data = cells_subset,
-    outcome = "class"
-  )
-
-  set.seed(42)
-  fit <- aorsf::orsf(
-    formula = class ~ .,
-    data = cells_subset,
-    n_tree = 10,
-    n_retry = 2,
-    importance = "permute"
-  )
-  imp <- fit$importance
-  outcome <- "class"
-  predictors <- setdiff(names(cells_subset), outcome)
-  exp.imp <- imp[predictors] |> unname()
-  exp.imp[is.na(exp.imp)] <- 0
-
-  expect_true(tibble::is_tibble(score_res))
-
-  expect_identical(nrow(score_res), ncol(cells_subset) - 1L)
-
-  expect_named(score_res, c("name", "score", "outcome", "predictor"))
-
-  expect_identical(score_res$score, exp.imp)
-
-  expect_equal(unique(score_res$name), "imp_rf_oblique")
-
-  expect_equal(unique(score_res$outcome), "class")
-})
-
-test_that("get_score_forest_importance() is working for ranger regression", {
-  skip_if_not_installed("modeldata")
-
   ames_subset <- helper_ames()
-  score_obj <- score_forest_imp(mode = "regression", seed = 42)
-  score_res <- get_scores_forest_importance(
-    score_obj,
-    data = ames_subset,
-    outcome = "Sale_Price"
-  )
+  ames_subset <- ames_subset |>
+    dplyr::mutate(Sale_Price = log10(Sale_Price))
 
-  outcome <- "Sale_Price"
-  y <- ames_subset[[outcome]]
-  X <- ames_subset[setdiff(names(ames_subset), outcome)]
-  fit <- ranger::ranger(
-    x = X,
+  regression_task <- score_imp_rf
+  regression_task@seed <- 42
+  regression_task@mode <- "regression"
+  set.seed(42)
+  ames_imp_rf_regression_task_res <-
+    regression_task |>
+    fit(Sale_Price ~ ., data = ames_subset)
+
+  # ----------------------------------------------------------------------------
+
+  y <- ames_subset[["Sale_Price"]]
+  X <- ames_subset[setdiff(names(ames_subset), "Sale_Price")]
+  fit_ranger <- ranger::ranger(
     y = y,
-    num.trees = 10,
+    x = X,
+    num.trees = 100,
     mtry = 2,
     importance = "permutation",
     min.node.size = 1,
     classification = FALSE,
     seed = 42
   )
-  exp.res <- unname(fit$variable.importance)
+  imp_ranger <- (fit_ranger$variable.importance) |> unname()
 
-  expect_true(tibble::is_tibble(score_res))
+  expect_equal(ames_imp_rf_regression_task_res@results$score, imp_ranger)
 
-  expect_identical(nrow(score_res), ncol(ames_subset) - 1L)
+  # ----------------------------------------------------------------------------
 
-  expect_named(score_res, c("name", "score", "outcome", "predictor"))
+  expect_equal(ames_imp_rf_regression_task_res@range, c(0.0, Inf))
+  expect_equal(ames_imp_rf_regression_task_res@inclusive, rep(FALSE, 2))
+  expect_equal(ames_imp_rf_regression_task_res@fallback_value, Inf)
+  expect_equal(ames_imp_rf_regression_task_res@direction, "maximize")
 
-  expect_identical(score_res$score, exp.res)
+  # ----------------------------------------------------------------------------
 
-  expect_equal(unique(score_res$name), "imp_rf")
-
-  expect_equal(unique(score_res$outcome), "Sale_Price")
+  expect_equal(ames_imp_rf_regression_task_res@mode, "regression")
 })
 
-test_that("get_score_forest_importance() is working for partykit regression", {
+test_that("computations - regression task via partykit", {
   skip_if_not_installed("modeldata")
-
   ames_subset <- helper_ames()
-  score_obj <- score_forest_imp(engine = "partykit")
-  set.seed(42)
-  score_res <- get_scores_forest_importance(
-    score_obj,
-    data = ames_subset,
-    outcome = "Sale_Price"
-  )
+  ames_subset <- ames_subset |>
+    dplyr::mutate(Sale_Price = log10(Sale_Price))
 
   set.seed(42)
-  fit <- partykit::cforest(
+  ames_imp_rf_conditional_res <- score_imp_rf_conditional |>
+    fit(Sale_Price ~ ., data = ames_subset)
+
+  # ----------------------------------------------------------------------------
+
+  set.seed(42)
+  fit_partykit <- partykit::cforest(
     formula = Sale_Price ~ .,
     data = ames_subset,
     control = partykit::ctree_control(minsplit = 1), # TODO Eventually have user pass in ctree_control()
-    ntree = 10,
+    ntree = 100,
     mtry = 2,
   )
-  imp <- partykit::varimp(fit, conditional = TRUE)
-  outcome <- "Sale_Price"
-  predictors <- setdiff(names(ames_subset), outcome)
-  exp.imp <- imp[predictors] |> unname()
-  exp.imp[is.na(exp.imp)] <- 0
+  imp_partykit_raw <- partykit::varimp(fit_partykit, conditional = TRUE)
+  predictors <- setdiff(names(ames_subset), "Sale_Price")
+  imp_partykit <- imp_partykit_raw[predictors] |> unname()
+  imp_partykit[is.na(imp_partykit)] <- 0
 
-  expect_true(tibble::is_tibble(score_res))
+  expect_equal(ames_imp_rf_conditional_res@results$score, imp_partykit)
 
-  expect_identical(nrow(score_res), ncol(ames_subset) - 1L)
+  # ----------------------------------------------------------------------------
 
-  expect_named(score_res, c("name", "score", "outcome", "predictor"))
-
-  expect_identical(score_res$score, exp.imp)
-
-  expect_equal(unique(score_res$name), "imp_rf_conditional")
-
-  expect_equal(unique(score_res$outcome), "Sale_Price")
+  expect_equal(ames_imp_rf_conditional_res@range, c(0.0, Inf))
+  expect_equal(ames_imp_rf_conditional_res@inclusive, rep(FALSE, 2))
+  expect_equal(ames_imp_rf_conditional_res@fallback_value, Inf)
+  expect_equal(ames_imp_rf_conditional_res@direction, "maximize")
 })
 
-test_that("get_score_forest_importance() is working for aorsf regression", {
+test_that("computations - regression task via aorsf", {
   skip_if_not_installed("modeldata")
-
   ames_subset <- helper_ames()
-  score_obj <- score_forest_imp(engine = "aorsf")
-  set.seed(42)
-  score_res <- get_scores_forest_importance(
-    score_obj,
-    data = ames_subset,
-    outcome = "Sale_Price"
-  )
+  ames_subset <- ames_subset |>
+    dplyr::mutate(Sale_Price = log10(Sale_Price))
 
   set.seed(42)
-  fit <- aorsf::orsf(
+  ames_imp_rf_oblique_res <- score_imp_rf_oblique |>
+    fit(Sale_Price ~ ., data = ames_subset)
+
+  # ----------------------------------------------------------------------------
+
+  set.seed(42)
+  fit_aorsf <- aorsf::orsf(
     formula = Sale_Price ~ .,
     data = ames_subset,
-    n_tree = 10,
+    n_tree = 100,
     n_retry = 2,
     importance = "permute"
   )
-  imp <- fit$importance
-  outcome <- "Sale_Price"
-  predictors <- setdiff(names(ames_subset), outcome)
-  exp.imp <- imp[predictors] |> unname()
-  exp.imp[is.na(exp.imp)] <- 0
+  imp_raw_aorsf <- fit_aorsf$importance
+  predictors <- setdiff(names(ames_subset), "Sale_Price")
+  imp_aorsf <- imp_raw_aorsf[predictors] |> unname()
+  imp_aorsf[is.na(imp_aorsf)] <- 0
 
-  expect_true(tibble::is_tibble(score_res))
+  expect_equal(ames_imp_rf_oblique_res@results$score, imp_aorsf)
 
-  expect_identical(nrow(score_res), ncol(ames_subset) - 1L)
+  # ----------------------------------------------------------------------------
 
-  expect_named(score_res, c("name", "score", "outcome", "predictor"))
-
-  expect_identical(score_res$score, exp.imp)
-
-  expect_equal(unique(score_res$name), "imp_rf_oblique")
-
-  expect_equal(unique(score_res$outcome), "Sale_Price")
+  expect_equal(ames_imp_rf_oblique_res@range, c(0.0, Inf))
+  expect_equal(ames_imp_rf_oblique_res@inclusive, rep(FALSE, 2))
+  expect_equal(ames_imp_rf_oblique_res@fallback_value, Inf)
+  expect_equal(ames_imp_rf_oblique_res@direction, "maximize")
 })
+
+# TODO Wrong variable type
+# TODO Required packages
 
 # TODO Test more after we add validators

--- a/tests/testthat/test-score-info_gain.R
+++ b/tests/testthat/test-score-info_gain.R
@@ -75,95 +75,83 @@ test_that("computations - class outcome", {
   expect_equal(cells_gain_ratio_res@direction, "maximize")
 })
 
-# numeric outcome
-ames_subset <- modeldata::ames |>
-  dplyr::select(
-    Sale_Price,
-    MS_SubClass,
-    MS_Zoning,
-    Lot_Frontage,
-    Lot_Area,
-    Street
-  )
-ames_subset <- ames_subset |>
-  dplyr::mutate(Sale_Price = log10(Sale_Price))
-
-regression_task <- score_info_gain
-regression_task@mode <- "regression"
-
-ames_info_gain_regression_task_res <-
-  regression_task |>
-  fit(Sale_Price ~ ., data = ames_subset)
-ames_info_gain_regression_task_res@results
-
-skip()
-
-test_that("get_scores_info_gain() is working for classification", {
+test_that("computations - numeric outcome", {
   skip_if_not_installed("modeldata")
+  ames_subset <- helper_ames()
+  ames_subset <- ames_subset |>
+    dplyr::mutate(Sale_Price = log10(Sale_Price))
 
-  cells_subset <- modeldata::cells |>
-    dplyr::select(
-      class,
-      angle_ch_1,
-      area_ch_1,
-      avg_inten_ch_1,
-      avg_inten_ch_2
-    )
+  regression_task <- score_info_gain
+  regression_task@mode <- "regression"
+  ames_info_gain_res <- regression_task |>
+    fit(Sale_Price ~ ., data = ames_subset)
 
-  score_obj <- score_info_gain()
-  score_res <- get_scores_info_gain(
-    score_obj,
-    data = cells_subset,
-    outcome = "class"
+  regression_task <- score_gain_ratio
+  regression_task@mode <- "regression"
+  ames_gain_ratio_res <- regression_task |>
+    fit(Sale_Price ~ ., data = ames_subset)
+
+  regression_task <- score_sym_uncert
+  regression_task@mode <- "regression"
+  ames_sym_uncert_res <- regression_task |>
+    fit(Sale_Price ~ ., data = ames_subset)
+
+  # ----------------------------------------------------------------------------
+
+  y <- ames_subset[["Sale_Price"]]
+  X <- ames_subset[setdiff(names(ames_subset), "Sale_Price")]
+  fit_infogain <- FSelectorRcpp::information_gain(
+    x = X,
+    y = y,
+    type = "infogain",
+    equal = TRUE
   )
+  imp_infogain <- fit_infogain$importance
+  imp_infogain[is.na(imp_infogain)] <- 0
 
-  outcome <- "class"
-  y <- cells_subset[[outcome]]
-  X <- cells_subset[setdiff(names(cells_subset), outcome)]
-  fit <- FSelectorRcpp::information_gain(x = X, y = y)
-  exp.res <- fit$importance
+  fit_gainratio <- FSelectorRcpp::information_gain(
+    x = X,
+    y = y,
+    type = "gainratio",
+    equal = TRUE
+  )
+  imp_gainratio <- fit_gainratio$importance
+  imp_gainratio[is.na(imp_gainratio)] <- 0
 
-  expect_true(tibble::is_tibble(score_res))
+  fit_symuncert <- FSelectorRcpp::information_gain(
+    x = X,
+    y = y,
+    type = "symuncert",
+    equal = TRUE
+  )
+  imp_symuncert <- fit_symuncert$importance
+  imp_symuncert[is.na(imp_symuncert)] <- 0
 
-  expect_identical(nrow(score_res), ncol(cells_subset) - 1L)
+  expect_equal(ames_info_gain_res@results$score, imp_infogain)
+  expect_equal(ames_gain_ratio_res@results$score, imp_gainratio)
+  expect_equal(ames_sym_uncert_res@results$score, imp_symuncert)
 
-  expect_named(score_res, c("name", "score", "outcome", "predictor"))
+  # ----------------------------------------------------------------------------
 
-  expect_identical(score_res$score, exp.res)
+  expect_equal(ames_info_gain_res@range, c(0.0, Inf))
+  expect_equal(ames_info_gain_res@inclusive, rep(FALSE, 2))
+  expect_equal(ames_info_gain_res@fallback_value, Inf)
+  expect_equal(ames_info_gain_res@direction, "maximize")
 
-  expect_equal(unique(score_res$name), "infogain")
+  # ----------------------------------------------------------------------------
 
-  expect_equal(unique(score_res$outcome), "class")
+  expect_equal(ames_gain_ratio_res@range, c(0.0, 1.0))
+  expect_equal(ames_gain_ratio_res@inclusive, rep(TRUE, 2))
+  expect_equal(ames_gain_ratio_res@fallback_value, 1.0)
+  expect_equal(ames_gain_ratio_res@direction, "maximize")
 })
 
-test_that("get_scores_info_gain() is working for regression", {
-  skip_if_not_installed("modeldata")
+# TODO computations - wrong variable types
 
-  ames_subset <- helper_ames()
-  score_obj <- score_info_gain(mode = "regression")
-  score_res <- get_scores_info_gain(
-    score_obj,
-    data = ames_subset,
-    outcome = "Sale_Price"
-  )
-
-  outcome <- "Sale_Price"
-  y <- ames_subset[[outcome]]
-  X <- ames_subset[setdiff(names(ames_subset), outcome)]
-  fit <- FSelectorRcpp::information_gain(x = X, y = y, equal = TRUE)
-  exp.res <- fit$importance
-
-  expect_true(tibble::is_tibble(score_res))
-
-  expect_identical(nrow(score_res), ncol(ames_subset) - 1L)
-
-  expect_named(score_res, c("name", "score", "outcome", "predictor"))
-
-  expect_identical(score_res$score, exp.res)
-
-  expect_equal(unique(score_res$name), "infogain")
-
-  expect_equal(unique(score_res$outcome), "Sale_Price")
+test_that("computations - required packages", {
+  expect_equal(required_pkgs(score_info_gain), "filtro")
+  expect_equal(required_pkgs(score_gain_ratio), "filtro")
+  expect_equal(required_pkgs(score_sym_uncert), "filtro")
 })
 
 # TODO Test more after we add validators

--- a/tests/testthat/test-score-roc_auc.R
+++ b/tests/testthat/test-score-roc_auc.R
@@ -43,10 +43,10 @@ test_that("computations - class outcome, binary", {
   expect_equal(cells_roc_auc_res@direction, "maximize")
 })
 
-
 test_that("computations - numeric outcome, multiclass predictors", {
   skip_if_not_installed("modeldata")
-  ames_subset <- helper_ames() |> dplyr::select(-Lot_Frontage, -Lot_Area) # Avoid dealing with NA here
+  # Avoid dealing with NA in pROC::multiclass.roc(); Somehow try() doesn't quite work.
+  ames_subset <- helper_ames() |> dplyr::select(-Lot_Frontage, -Lot_Area)
   ames_subset <- ames_subset |>
     dplyr::mutate(Sale_Price = log10(Sale_Price))
 


### PR DESCRIPTION
Rewrite tests for: 

- score forest imp classification (all 3 types of engines) 
- score forest imp regression (all 3 types of engines) 
- score info gain class outcome 
- score ingo gain numeric outcome
- score for roc auc class outcome, binary
- score for roc auc class outcome, multiclass
- score for numeric outcome, binary and multiclass predictors

TODO

- [ ] Tests computations - wrong variable types (After closing [#75](https://github.com/tidymodels/filtro/issues/75))
