### PR TITLE
Add a helper dont_log_pvalues() for score aov

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -583,6 +583,11 @@ flip_if_needed_aov <- function(predictor, outcome) {
   }
 }
 
+dont_log_pvalues <- function(x) {
+  x@neg_log10 <- FALSE
+  x
+}
+
 # ------------------------------------------------------------------------------
 # Used with ROC AUC methods
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -583,6 +583,7 @@ flip_if_needed_aov <- function(predictor, outcome) {
   }
 }
 
+# Need to export this
 dont_log_pvalues <- function(x) {
   x@neg_log10 <- FALSE
   x

--- a/tests/testthat/test-score-aov.R
+++ b/tests/testthat/test-score-aov.R
@@ -22,8 +22,8 @@ test_that("aov computations - class outcome", {
     score_aov_pval |>
     fit(class ~ ., data = cell_data)
 
-  natrual_units <- score_aov_pval
-  natrual_units@neg_log10 <- FALSE
+  natrual_units <- score_aov_pval |> dont_log_pvalues()
+  #natrual_units@neg_log10 <- FALSE
 
   cell_pval_natrual_res <-
     natrual_units |>
@@ -87,7 +87,9 @@ test_that("aov computations - numeric outcome", {
   for (i in predictors) {
     fstat <- perm_fstat_res@results[perm_fstat_res@results$predictor == i, ]
     lg10 <- perm_pval_res@results[perm_fstat_res@results$predictor == i, ]
-    nat <- perm_pval_natrual_res@results[perm_fstat_res@results$predictor == i,]
+    nat <- perm_pval_natrual_res@results[
+      perm_fstat_res@results$predictor == i,
+    ]
 
     num_x <- length(unique(perm_data[[i]]))
     if (num_x == 1) {
@@ -152,11 +154,8 @@ test_that("aov computations - wrong variable types", {
     fit(Sale_Price ~ ., data = ames_data_chr)
 
   expect_true(all(is.na(ames_chr_res@results$score)))
-
 })
 
 test_that("aov computations - required packages", {
-
   expect_equal(required_pkgs(score_aov_pval), "filtro")
-
 })

--- a/tests/testthat/test-score-aov.R
+++ b/tests/testthat/test-score-aov.R
@@ -61,7 +61,6 @@ test_that("aov computations - class outcome", {
   expect_equal(cell_pval_natrual_res@direction, "minimize")
 })
 
-
 test_that("aov computations - numeric outcome", {
   skip_if_not_installed("modeldata")
   perm_data <- helper_perm_factors()


### PR DESCRIPTION
Close #74

reprex doesn't quite work but

```
cell_data <- modeldata::cells |>
    dplyr::select(
      class,
      angle_ch_1,
      area_ch_1,
      avg_inten_ch_1,
      avg_inten_ch_2,
      avg_inten_ch_3
    )

cell_pval_res <-
    score_aov_pval |>
    fit(class ~ ., data = cell_data)

natrual_units <- score_aov_pval |> dont_log_pvalues() # Call this 
#natrual_units@neg_log10 <- FALSE # Instead of calling this 

cell_pval_natrual_res <-
    natrual_units |>
    fit(class ~ ., data = cell_data)
```
