### PR TITLE
Refactor interpretation and passing of arguments to random forest packages

### DIFF
--- a/R/score-forest_imp.R
+++ b/R/score-forest_imp.R
@@ -8,8 +8,6 @@ class_score_imp_rf <- S7::new_class(
   properties = list(
     # What is the random forest engine to use for fitting?
     engine = S7::new_property(S7::class_character, default = "ranger"),
-    # What is the task type? Relevant only for ranger.
-    mode = S7::new_property(S7::class_character, default = "classification"), # TODO True, False?
     # What is the random seed?
     seed = S7::new_property(S7::class_numeric, default = 42)
   )
@@ -224,8 +222,7 @@ get_imp_rf_ranger <- function(object, data, outcome, ...) {
     .ns = "ranger",
     x = quote(X),
     y = quote(y),
-    importance = quote(importance_type),
-    classification = object@mode == "classification"
+    importance = quote(importance_type)
   )
 
   # if (!is.null(case_weights)) {

--- a/R/score-forest_imp.R
+++ b/R/score-forest_imp.R
@@ -7,9 +7,7 @@ class_score_imp_rf <- S7::new_class(
   parent = class_score,
   properties = list(
     # What is the random forest engine to use for fitting?
-    engine = S7::new_property(S7::class_character, default = "ranger"),
-    # What is the random seed?
-    seed = S7::new_property(S7::class_numeric, default = 42)
+    engine = S7::new_property(S7::class_character, default = "ranger")
   )
 )
 
@@ -233,8 +231,10 @@ get_imp_rf_ranger <- function(object, data, outcome, ...) {
 
   opts <- convert_rf_args(opts, "ranger")
   # Keep consistent with parsnip
-  opts <- update_defaults(opts, list(verbose = FALSE, num.threads = 1))
-
+  opts <- update_defaults(
+    opts,
+    list(verbose = FALSE, num.threads = 1, seed = sample.int(1000, 1))
+  )
   cl <- rlang::call_modify(cl, !!!opts)
 
   fit <- rlang::eval_tidy(cl)

--- a/man/class_score.Rd
+++ b/man/class_score.Rd
@@ -103,8 +103,7 @@ class_score_imp_rf(
   label = character(0),
   packages = character(0),
   results = data.frame(),
-  engine = "ranger",
-  seed = 42
+  engine = "ranger"
 )
 
 class_score_info_gain(

--- a/man/class_score.Rd
+++ b/man/class_score.Rd
@@ -104,10 +104,6 @@ class_score_imp_rf(
   packages = character(0),
   results = data.frame(),
   engine = "ranger",
-  trees = 100,
-  mtry = 2,
-  min_n = 1,
-  mode = "classification",
   seed = 42
 )
 

--- a/man/score_aov_pval.Rd
+++ b/man/score_aov_pval.Rd
@@ -25,6 +25,10 @@ processed via \code{\link[stats:model.frame]{stats::model.frame()}}.}
 \item{data}{A data frame containing the relevant columns defined by the
 formula.}
 
+\item{case_weights}{A quantitative vector of case weights that is the same
+length as the number of rows in \code{data}. The default of \code{NULL} indicates that
+there are no case weights.}
+
 \item{...}{Further arguments passed to or from other methods.}
 }
 \description{
@@ -54,8 +58,7 @@ The function will determine which columns are predictors and outcomes in the
 linear model; no user intervention is required.
 
 Missing values are removed for each predictor/outcome combination being
-scored.
-In cases where \code{\link[=lm]{lm()}} or \code{\link[=anova]{anova()}} fail, the scoring proceeds silently, and
+scored. In cases where \code{\link[=lm]{lm()}} or \code{\link[=anova]{anova()}} fail, the scoring proceeds silently, and
 a missing value is given for the score.
 }
 \examples{

--- a/man/score_imp_rf.Rd
+++ b/man/score_imp_rf.Rd
@@ -89,7 +89,7 @@ cells_imp_rf_res@results
 
 # Conditional random forest
 cells_imp_rf_conditional_res <- score_imp_rf_conditional |>
-  fit(class ~ ., data = cells_subset)
+  fit(class ~ ., data = cells_subset, trees = 10)
 cells_imp_rf_conditional_res@results
 
 # Oblique random forest

--- a/tests/testthat/test-score-forest_imp.R
+++ b/tests/testthat/test-score-forest_imp.R
@@ -15,6 +15,80 @@ test_that("object creation", {
   )
 })
 
+# ------------------------------------------------------------------------------
+
+test_that("updating ranger args", {
+
+  before_1 <- list()
+  after_1 <- convert_rf_args(before_1, method = "ranger")
+  expect_equal(before_1, after_1)
+
+  before_2 <- list(mtry = 5)
+  after_2 <- convert_rf_args(before_2, method = "ranger")
+  expect_equal(after_2, before_2)
+
+  # leave engine/original args alone
+  before_3 <- list(trees = 5, regularization.factor = 1/2, min.node.size = 1)
+  after_3 <- convert_rf_args(before_3, method = "ranger")
+  expect_equal(
+    after_3,
+    list(num.trees = 5, regularization.factor = 0.5, min.node.size = 1)
+  )
+
+  # All conversions
+  before_4 <- list(trees = 5, min_n = 1, mtry = 3)
+  after_4 <- convert_rf_args(before_4, method = "ranger")
+  expect_equal(
+    after_4,
+    list(num.trees = 5, min.node.size = 1, mtry = 3)
+  )
+})
+
+test_that("updating cforest args", {
+
+  # All conversions
+  before_1 <- list(trees = 5, min_n = 1, mtry = 3)
+  after_1 <- convert_rf_args(before_1, method = "partykit")
+  expect_equal(
+    after_1,
+    list(ntree = 5, minsplit = 1, mtry = 3)
+  )
+
+})
+
+test_that("updating cforest args", {
+
+  # All conversions
+  before_1 <- list(trees = 5, min_n = 1, mtry = 3)
+  after_1 <- convert_rf_args(before_1, method = "aorsf")
+  expect_equal(
+    after_1,
+    list(n_tree = 5, leaf_min_obs = 1, mtry = 3)
+  )
+
+})
+
+test_that("updating with default args", {
+
+  expect_equal(
+    update_defaults(list(a = 1, b = 2), list()),
+    list(a = 1, b = 2)
+  )
+
+  expect_equal(
+    update_defaults(list(a = 1, b = 2), list(a = 3)),
+    list(a = 1, b = 2)
+  )
+
+  expect_equal(
+    update_defaults(list(a = 1, b = 2), list(c = 3)),
+    list(c = 3, a = 1, b = 2)
+  )
+
+})
+
+# ------------------------------------------------------------------------------
+
 test_that("computations - classification task via ranger", {
   skip_if_not_installed("modeldata")
   cells_subset <- helper_cells()
@@ -150,6 +224,8 @@ test_that("computations - regression task via ranger vary trees, mtry, min_n", {
   expect_equal(ames_imp_rf_regression_task_res@mode, "regression")
 })
 
+# ------------------------------------------------------------------------------
+
 test_that("computations - classification task via partykit", {
   skip_if_not_installed("modeldata")
   cells_subset <- helper_cells()
@@ -225,6 +301,8 @@ test_that("computations - regression task via partykit", {
   expect_equal(ames_imp_rf_conditional_res@fallback_value, Inf)
   expect_equal(ames_imp_rf_conditional_res@direction, "maximize")
 })
+
+# ------------------------------------------------------------------------------
 
 test_that("computations - classification task via aorsf", {
   skip_if_not_installed("modeldata")


### PR DESCRIPTION
This PR creates some helper functions to manage the transition between parsnip's controlled vocabulary of argument names and the different syntaxes of the engine packages. Either or both can be used. 

It simplifies a few things. A number of properties are no longer needed: `seed`, `mode`, and the various tuning parameters. 

The testing also fits more efficient/smaller partykit examples so it is more efficient. 