### PR TITLE
Handle mode in switch for info gain 

### DIFF
--- a/R/score-info_gain.R
+++ b/R/score-info_gain.R
@@ -177,7 +177,7 @@ S7::method(fit, class_score_info_gain) <- function(object, formula, data, ...) {
   predictors <- names(analysis_data)[-1]
   outcome <- names(analysis_data)[1]
 
-  if (is.numeric(analysis_data[outcome])) {
+  if (is.numeric(analysis_data[[outcome]])) {
     object@mode <- "regression"
   }
 

--- a/R/score-info_gain.R
+++ b/R/score-info_gain.R
@@ -7,7 +7,7 @@ class_score_info_gain <- S7::new_class(
   parent = class_score,
   properties = list(
     # What is the task type?
-    mode = S7::new_property(S7::class_character, default = "classification") # TODO True, False?
+    mode = S7::new_property(S7::class_character, default = "classification")
   )
 )
 
@@ -176,6 +176,10 @@ S7::method(fit, class_score_info_gain) <- function(object, formula, data, ...) {
   # Note that model.frame() places the outcome(s) as the first column(s)
   predictors <- names(analysis_data)[-1]
   outcome <- names(analysis_data)[1]
+
+  if (is.numeric(analysis_data[outcome])) {
+    object@mode <- "regression"
+  }
 
   imp <- get_info_gain(object, data = analysis_data, outcome = outcome)
 

--- a/tests/testthat/test-score-info_gain.R
+++ b/tests/testthat/test-score-info_gain.R
@@ -82,17 +82,14 @@ test_that("computations - numeric outcome", {
     dplyr::mutate(Sale_Price = log10(Sale_Price))
 
   regression_task <- score_info_gain
-  regression_task@mode <- "regression"
   ames_info_gain_res <- regression_task |>
     fit(Sale_Price ~ ., data = ames_subset)
 
   regression_task <- score_gain_ratio
-  regression_task@mode <- "regression"
   ames_gain_ratio_res <- regression_task |>
     fit(Sale_Price ~ ., data = ames_subset)
 
   regression_task <- score_sym_uncert
-  regression_task@mode <- "regression"
   ames_sym_uncert_res <- regression_task |>
     fit(Sale_Price ~ ., data = ames_subset)
 


### PR DESCRIPTION
Close #113 

Now whether to turn on `equal = TRUE` for numeric outcome is handled in switch.

Previously, user needs to call

  regression_task <- score_info_gain
  score_info_gain@mode <- "regression"        # Change mode to handle numeric outcome 
  ames_info_gain_res <- regression_task |>
    fit(Sale_Price ~ ., data = ames_subset)

Now, user can call 

```
  regression_task <- score_info_gain
  ames_info_gain_res <- regression_task |>
    fit(Sale_Price ~ ., data = ames_subset)
```
