### PR TITLE
Modify utilities

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -75,7 +75,7 @@ fill_safe_value <- S7::new_generic("fill_safe_value", dispatch_args = "x")
 #'
 #' @param x A score class object, i.e., `score_*`.
 #'
-#' @param ... Further arguments passed to or from other methods.
+#' @param return_results A logical value indicating whether to return results.
 #'
 #' @examplesIf rlang::is_installed("modeldata")
 #'
@@ -99,15 +99,22 @@ fill_safe_value <- S7::new_generic("fill_safe_value", dispatch_args = "x")
 #' ames_aov_pval_res@results
 #'
 #' # Fill safe value
-#' ames_aov_pval_res |> fill_safe_value()
+#' ames_aov_pval_res |> fill_safe_value(return_results = TRUE)
 #'
 #' @export
-S7::method(fill_safe_value, class_score) <- function(x) {
+S7::method(fill_safe_value, class_score) <- function(
+  x,
+  return_results = FALSE
+) {
   results <- x@results
   is_na_score <- is.na(results$score)
   results$score[is_na_score] <- x@fallback_value
   x@results <- results
-  x@results
+  if (return_results) {
+    x@results
+  } else {
+    x
+  }
 }
 
 #' @keywords internal

--- a/README.Rmd
+++ b/README.Rmd
@@ -131,7 +131,19 @@ ames_info_gain_reg_res <-
 ames_info_gain_reg_res@results
 ```
 
-## A filtering exmple for *singular* score
+## A filtering exmple for score *singular* 
+
+There are several methods for score *singular*: 
+
+- `show_best_score_prop()` shows best score, based on proportion of predictors.
+
+- `show_best_score_num()` shows best score, based on number of predictors.
+
+- `show_best_score_cutoff()` shows best score, based on based on cutoff value.
+
+- `show_best_score_dual()` shows best score, based on number or proportion of predictors with optional cutoff value. 
+
+For one example: 
 
 ```{r}
 ames_aov_pval_res@results
@@ -142,27 +154,22 @@ ames_aov_pval_res@results
 ames_aov_pval_res |> show_best_score_prop(prop_terms = 0.2)
 ```
 
-```{r}
-# Show best score, based on number of predictors
-ames_aov_pval_res |> show_best_score_num(num_terms = 2)
-```
+There is an option to fill safe value first, and then show best score using various methods. 
 
 ```{r}
-# Show best score, based on based on cutoff value
-ames_aov_pval_res |> show_best_score_cutoff(cutoff = 130)
+# Fill safe value
+ames_aov_pval_res <- ames_aov_pval_res |> fill_safe_value()
+# Show best score, based on proportion of predictors
+ames_aov_pval_res |> show_best_score_prop(prop_terms = 0.2)
 ```
 
-```{r}
-# Show best score, based on number or proportion of predictors with
-# optional cutoff value 
-ames_aov_pval_res |> show_best_score_dual(prop_terms = 0.5)
-ames_aov_pval_res |> show_best_score_dual(prop_terms = 0.5, cutoff = 130)
+## A filtering example for scores *plural* 
 
-ames_aov_pval_res |> show_best_score_dual(num_terms = 2)
-ames_aov_pval_res |> show_best_score_dual(prop_terms = 2, cutoff = 130)
-```
+There are several methods for score *plural*: 
 
-## A filtering example for *plural* scores
+- `show_best_desirability_prop()`
+
+- `show_best_desirability_num()`
 
 ```{r}
 # Create a list
@@ -182,6 +189,8 @@ ames_scores_results <- class_score_list |>
   dplyr::select(-outcome)
 ames_scores_results
 ```
+
+For one example: 
 
 ```{r}
 # Single and multi-parameter optimization using desirability functions

--- a/README.md
+++ b/README.md
@@ -150,7 +150,23 @@ ames_info_gain_reg_res@results
 #> 5 infogain 0.00365 Sale_Price Street
 ```
 
-## A filtering exmple for *singular* score
+## A filtering exmple for score *singular*
+
+There are several methods for score *singular*:
+
+- `show_best_score_prop()` shows best score, based on proportion of
+  predictors.
+
+- `show_best_score_num()` shows best score, based on number of
+  predictors.
+
+- `show_best_score_cutoff()` shows best score, based on based on cutoff
+  value.
+
+- `show_best_score_dual()` shows best score, based on number or
+  proportion of predictors with optional cutoff value.
+
+For one example:
 
 ``` r
 ames_aov_pval_res@results
@@ -173,54 +189,28 @@ ames_aov_pval_res |> show_best_score_prop(prop_terms = 0.2)
 #> 1 aov_pval  237. Sale_Price MS_SubClass
 ```
 
-``` r
-# Show best score, based on number of predictors
-ames_aov_pval_res |> show_best_score_num(num_terms = 2)
-#> # A tibble: 2 × 4
-#>   name     score outcome    predictor  
-#>   <chr>    <dbl> <chr>      <chr>      
-#> 1 aov_pval  237. Sale_Price MS_SubClass
-#> 2 aov_pval  130. Sale_Price MS_Zoning
-```
+There is an option to fill safe value first, and then show best score
+using various methods.
 
 ``` r
-# Show best score, based on based on cutoff value
-ames_aov_pval_res |> show_best_score_cutoff(cutoff = 130)
-#> # A tibble: 1 × 4
-#>   name     score outcome    predictor  
-#>   <chr>    <dbl> <chr>      <chr>      
-#> 1 aov_pval  237. Sale_Price MS_SubClass
+# Fill safe value
+ames_aov_pval_res <- ames_aov_pval_res |> fill_safe_value()
+# Show best score, based on proportion of predictors
+ames_aov_pval_res |> show_best_score_prop(prop_terms = 0.2)
+#> # A tibble: 2 × 4
+#>   name     score outcome    predictor   
+#>   <chr>    <dbl> <chr>      <chr>       
+#> 1 aov_pval   Inf Sale_Price Lot_Frontage
+#> 2 aov_pval   Inf Sale_Price Lot_Area
 ```
 
-``` r
-# Show best score, based on number or proportion of predictors with
-# optional cutoff value 
-ames_aov_pval_res |> show_best_score_dual(prop_terms = 0.5)
-#> # A tibble: 2 × 4
-#>   name     score outcome    predictor  
-#>   <chr>    <dbl> <chr>      <chr>      
-#> 1 aov_pval  237. Sale_Price MS_SubClass
-#> 2 aov_pval  130. Sale_Price MS_Zoning
-ames_aov_pval_res |> show_best_score_dual(prop_terms = 0.5, cutoff = 130)
-#> # A tibble: 1 × 4
-#>   name     score outcome    predictor  
-#>   <chr>    <dbl> <chr>      <chr>      
-#> 1 aov_pval  237. Sale_Price MS_SubClass
+## A filtering example for scores *plural*
 
-ames_aov_pval_res |> show_best_score_dual(num_terms = 2)
-#> # A tibble: 2 × 4
-#>   name     score outcome    predictor  
-#>   <chr>    <dbl> <chr>      <chr>      
-#> 1 aov_pval  237. Sale_Price MS_SubClass
-#> 2 aov_pval  130. Sale_Price MS_Zoning
-ames_aov_pval_res |> show_best_score_dual(prop_terms = 2, cutoff = 130)
-#> # A tibble: 1 × 4
-#>   name     score outcome    predictor  
-#>   <chr>    <dbl> <chr>      <chr>      
-#> 1 aov_pval  237. Sale_Price MS_SubClass
-```
+There are several methods for score *plural*:
 
-## A filtering example for *plural* scores
+- `show_best_desirability_prop()`
+
+- `show_best_desirability_num()`
 
 ``` r
 # Create a list
@@ -248,6 +238,8 @@ ames_scores_results
 #> 4 Lot_Area       Inf          0.255 0.0144     0.140  
 #> 5 Street           5.75       1     0.0000308  0.00365
 ```
+
+For one example:
 
 ``` r
 # Single and multi-parameter optimization using desirability functions

--- a/man/fill_safe_value.Rd
+++ b/man/fill_safe_value.Rd
@@ -6,7 +6,7 @@
 \arguments{
 \item{x}{A score class object, i.e., \verb{score_*}.}
 
-\item{...}{Further arguments passed to or from other methods.}
+\item{return_results}{A logical value indicating whether to return results.}
 }
 \description{
 Fills in safe value for missing score. This is a \emph{singular} scoring method.
@@ -35,6 +35,6 @@ ames_aov_pval_res <-
 ames_aov_pval_res@results
 
 # Fill safe value
-ames_aov_pval_res |> fill_safe_value()
+ames_aov_pval_res |> fill_safe_value(return_results = TRUE)
 \dontshow{\}) # examplesIf}
 }

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -34,10 +34,12 @@ ames_aov_fstat_res <-
   fit(Sale_Price ~ ., data = ames_subset)
 
 ames_aov_pval_res@results
-ames_aov_pval_res |> fill_safe_value()
+ames_aov_pval_res |> fill_safe_value(return_results = TRUE)
+ames_aov_pval_res |> fill_safe_value() |> show_best_score_prop(prop_terms = 0.2)
 
-ames_aov_fstat_res@results
-ames_aov_fstat_res |> fill_safe_value()
+# START HERE
+
+ames_aov_pval_res |> fill_safe_value()
 
 # Show best score based on based on proportion of predictors
 
@@ -52,8 +54,6 @@ ames_aov_pval_res <-
 ames_aov_fstat_res <-
   score_aov_fstat |>
   fit(Sale_Price ~ ., data = ames_subset)
-
-# START HERE
 
 ames_aov_pval_res@results
 ames_aov_pval_res |> show_best_score_prop(prop_terms = 0.2)

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -53,6 +53,8 @@ ames_aov_fstat_res <-
   score_aov_fstat |>
   fit(Sale_Price ~ ., data = ames_subset)
 
+# START HERE
+
 ames_aov_pval_res@results
 ames_aov_pval_res |> show_best_score_prop(prop_terms = 0.2)
 


### PR DESCRIPTION
Close #116

Enable 

`ames_aov_pval_res |> fill_safe_value() |> show_best_score_prop(prop_terms = 0.2)`

i.e., 

```
ames_aov_pval_res <- ames_aov_pval_res |> fill_safe_value()
ames_aov_pval_res |> show_best_score_prop(prop_terms = 0.2)
```

Modify README accordingly 
