### PR TITLE
Isolate GitHub Actions RMD check error for windows CI

### DIFF
--- a/vignettes/filtro.qmd
+++ b/vignettes/filtro.qmd
@@ -22,8 +22,6 @@ knitr::opts_chunk$set(
 ```{r}
 #| label: start
 #| include: false
-library(pak)
-pak::pak("tidymodels/filtro")
 library(filtro)
 library(desirability2)
 library(dplyr)


### PR DESCRIPTION
Close #153 

FYI, `fill_safe_value()` has been rewritten in previous a PR ([#147](https://github.com/tidymodels/filtro/pull/147)), but all changes are on main.  
