### PR TITLE
Allow single score usage for bind_scores() and fill_safe_values()

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -689,11 +689,14 @@ bind_scores <- S7::new_generic("bind_scores", dispatch_args = "x")
 #' @export
 S7::method(bind_scores, class_score_list) <- function(x) {
   length_x <- length(x)
-  if (length_x < 2) {
-    score_set <- x[[1]]@results
-  } else {
+  if (length_x == 0) {
+    cli::cli_abort(
+      "{.arg x} must contain at least one element"
+    )
+  }
+  score_set <- x[[1]]@results
+  if (length_x > 1) {
     # TODO Check for identical score object, e.g., list(score_obj_aov, score_obj_aov)
-    score_set <- x[[1]]@results
     for (i in 2:length_x) {
       score_set <- dplyr::full_join(
         score_set,

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -690,9 +690,7 @@ bind_scores <- S7::new_generic("bind_scores", dispatch_args = "x")
 S7::method(bind_scores, class_score_list) <- function(x) {
   length_x <- length(x)
   if (length_x < 2) {
-    cli::cli_abort(
-      "{.arg x} must contain at least two elements"
-    )
+    score_set <- x[[1]]@results
   } else {
     # TODO Check for identical score object, e.g., list(score_obj_aov, score_obj_aov)
     score_set <- x[[1]]@results

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -438,9 +438,9 @@ test_that("computation - bind scores", {
     ames_cor_pearson_res
   )
 
-  res <- class_score_list |> bind_scores()
+  res_single <- class_score_list |> bind_scores()
 
-  expect_named(res, c("outcome", "predictor", "cor_pearson"))
+  expect_named(res_single, c("outcome", "predictor", "cor_pearson"))
 })
 
 test_that("computation - fill safe values", {
@@ -510,9 +510,9 @@ test_that("computation - fill safe values", {
     ames_cor_pearson_res
   )
 
-  res <- class_score_list |> fill_safe_values()
+  res_single <- class_score_list |> fill_safe_values()
 
-  expect_named(res, c("outcome", "predictor", "cor_pearson"))
+  expect_named(res_single, c("outcome", "predictor", "cor_pearson"))
 })
 
 # TODO Some tests are not exhaustive and can be improved

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -424,6 +424,23 @@ test_that("computation - bind scores", {
   expect_equal(res$cor_pearson, exp_res$cor_pearson)
   expect_equal(res$imp_rf, exp_res$imp_rf)
   expect_equal(res$infogain, exp_res$infogain)
+
+  # ----------------------------------------------------------------------------
+  # Single score
+
+  # cor
+  ames_cor_pearson_res <-
+    score_cor_pearson |>
+    fit(Sale_Price ~ ., data = ames_subset)
+
+  # Create a list
+  class_score_list <- list(
+    ames_cor_pearson_res
+  )
+
+  res <- class_score_list |> bind_scores()
+
+  expect_named(res, c("outcome", "predictor", "cor_pearson"))
 })
 
 test_that("computation - fill safe values", {

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -496,6 +496,23 @@ test_that("computation - fill safe values", {
   expect_equal(res$cor_pearson, exp_res$cor_pearson)
   expect_equal(res$imp_rf, exp_res$imp_rf)
   expect_equal(res$infogain, exp_res$infogain)
+
+  # ----------------------------------------------------------------------------
+  # Single score
+
+  # cor
+  ames_cor_pearson_res <-
+    score_cor_pearson |>
+    fit(Sale_Price ~ ., data = ames_subset)
+
+  # Create a list
+  class_score_list <- list(
+    ames_cor_pearson_res
+  )
+
+  res <- class_score_list |> fill_safe_values()
+
+  expect_named(res, c("outcome", "predictor", "cor_pearson"))
 })
 
 # TODO Some tests are not exhaustive and can be improved


### PR DESCRIPTION
Close #164

- `bind_scores()` can now handle a single score 
- `fill_safe_values()` too
- tests are added accordingly for each method
