### PR TITLE
Get rid of @mode in #' @examplesIf for info gain

### DIFF
--- a/R/score-info_gain.R
+++ b/R/score-info_gain.R
@@ -110,13 +110,10 @@ class_score_info_gain <- S7::new_class(
 #' ames_subset <- ames_subset |>
 #'   dplyr::mutate(Sale_Price = log10(Sale_Price))
 #'
-#' regression_task <- score_info_gain
-#' regression_task@mode <- "regression"
-#'
-#' ames_info_gain_regression_task_res <-
-#'   regression_task |>
+#' ames_info_gain_res <-
+#'   score_info_gain |>
 #'   fit(Sale_Price ~ ., data = ames_subset)
-#' ames_info_gain_regression_task_res@results
+#' ames_info_gain_res@results
 #' @export
 score_info_gain <-
   class_score_info_gain(

--- a/R/score-info_gain.R
+++ b/R/score-info_gain.R
@@ -201,7 +201,7 @@ get_info_gain <- function(object, data, outcome) {
       x = X,
       y = y,
       type = object@score_type,
-      equal = object@mode == "regression" # Set = TRUE for numeric outcome
+      equal = object@mode == "regression" # Set equal = TRUE for numeric outcome
     ),
     silent = TRUE
   )

--- a/man/score_info_gain.Rd
+++ b/man/score_info_gain.Rd
@@ -118,13 +118,10 @@ ames_subset <- modeldata::ames |>
 ames_subset <- ames_subset |>
   dplyr::mutate(Sale_Price = log10(Sale_Price))
 
-regression_task <- score_info_gain
-regression_task@mode <- "regression"
-
-ames_info_gain_regression_task_res <-
-  regression_task |>
+ames_info_gain_res <-
+  score_info_gain |>
   fit(Sale_Price ~ ., data = ames_subset)
-ames_info_gain_regression_task_res@results
+ames_info_gain_res@results
 \dontshow{\}) # examplesIf}
 }
 \seealso{


### PR DESCRIPTION
Edit the documentation to reflect the latest changes for info gain. 

Previously, user have to set `object@mode <- "regression"` for regression task. They don't now, and this PR reflects the changes. 